### PR TITLE
Add args to Main/Execute definition

### DIFF
--- a/src/SharpGen.cs
+++ b/src/SharpGen.cs
@@ -437,7 +437,7 @@ using SharpSploit.Misc;
 
 public static class {0}
 {{
-    static {1} {2}()
+    static {1} {2}(string[] args)
     {{
         {3}
     }}


### PR DESCRIPTION
This allows code within the Main/Execute function to take arguments.

I'm mostly interested in adding this because arguments passed to Cobalt Strike's `bexecute_assembly` function don't show up in `Environment.GetCommandLineArgs()` for some reason. For example:
    
    beacon> client cat /tmp/args.cs
    foreach (string arg in args) {
    	Console.WriteLine(" - " + arg);
    }
    Console.WriteLine("");
    
    foreach (string arg in Environment.GetCommandLineArgs()) {
    	Console.WriteLine(" - " + arg);
    }
    
    beacon> sharpgen-execute-file /tmp/args.cs arg1 arg2 arg3
    [*] Tasked beacon to execute C# code from: /tmp/args.cs
    [+] host called home, sent: 936007 bytes
    [+] received output:
     - arg1
     - arg2
     - arg3
    
     - C:\Users\user3\Desktop\beacon.exe